### PR TITLE
Install bower dependencies in project, not root

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "/vendor/bower"
+  "directory": "./vendor/bower"
 }


### PR DESCRIPTION
Bower wanted to install everything in /vendor of the root of my hard drive.
