### PR TITLE
Update calendar.directive.coffee

### DIFF
--- a/src/js/calendar.directive.coffee
+++ b/src/js/calendar.directive.coffee
@@ -50,7 +50,7 @@ angular.module('angular-date-picker-polyfill')
           unless aaDateUtil.dateObjectsAreEqualToMonth(d, scope.monthDate)
             pullMonthDateFromModel()
           refreshView()
-          scope.$emit('aa:calendar:set-date')
+          scope.$emit('aa:calendar:set-date', c)
 
         scope.setToToday = ->
           scope.setDate(aaDateUtil.todayStart())


### PR DESCRIPTION
Pass the new date as part of the emitted event.  This enables the consumer to react to the new value, not just any change.  For example, the consumer might do something like this:
```
    $scope.$on('aa:calendar:set-date', valueChanged);
    function valueChanged(event, data) {
            if (data && data instanceof Date) $scope.internalValue = data;
    }
```
(I needed this on my site.)